### PR TITLE
Bug: Update Status values to match documented spec

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,14 +26,14 @@ module.exports = function () {
         },
 
         async reportTestDone (name, testRunInfo) {
-            let testStatus = 'UNDEFINED';
+            let testStatus = 'TODO';
             const currentEvidences = {};
 
             const testStartDate = new Date();
 
             currentTest.testKey = ''; //still didn't find a way to get testKey so it stays empty for now
             if (!testRunInfo.skipped && JSON.stringify(testRunInfo.errs).replace(/[[\]]/g, '').length > 0) {
-                testStatus = 'FAIL';
+                testStatus = 'FAILED';
                 currentTest.evidences = [];
 
                 for (var i in testRunInfo.screenshots) {
@@ -46,7 +46,7 @@ module.exports = function () {
             }
             else {
                 testRunInfo = 'Test executed without any error';
-                testStatus = 'PASS';
+                testStatus = 'PASSED';
             }
             currentTest.comment = testRunInfo;
             currentTest.status = testStatus;


### PR DESCRIPTION
The documented spec for the Xray JSON Execution Results lists these Status values:

["TODO", "FAILED", "PASSED", "EXECUTING"]

This PR updates the code accordingly to use correct Status values where appropriate.

Here's the spec:
https://docs.getxray.app/display/XRAYCLOUD/Import+Execution+Results#ImportExecutionResults-XrayJSONformat